### PR TITLE
feat: add max_concurrency option

### DIFF
--- a/lib/rangescan/cli.rb
+++ b/lib/rangescan/cli.rb
@@ -12,6 +12,7 @@ module RangeScan
     method_option :timeout, type: :numeric, desc: "Timeout in seconds"
     method_option :user_agent, type: :string, desc: "User Agent"
     method_option :verify_ssl, type: :boolean, desc: "Whether to verify SSL or not"
+    method_option :max_concurrency, type: :numeric, desc: "Concurrency limit for HTTP requests to scan"
     def scan(ip_with_subnet_mask, regexp)
       symbolized_options = symbolize_hash_keys(options)
       range = Range.new(ip_with_subnet_mask)

--- a/spec/range_scan/scanner_spec.rb
+++ b/spec/range_scan/scanner_spec.rb
@@ -2,6 +2,7 @@
 
 require "glint"
 require "webrick"
+require "etc"
 
 HOST = "127.0.0.1"
 
@@ -73,6 +74,18 @@ RSpec.describe RangeScan::Scanner do
     it do
       scanner = described_class.new
       expect(scanner.port).to eq(80)
+    end
+  end
+
+  describe "#max_concurrency" do
+    it do
+      scanner = described_class.new(scheme: "http")
+      expect(scanner.max_concurrency).to eq(Etc.nprocessors * 2)
+    end
+
+    it do
+      scanner = described_class.new(scheme: "https", max_concurrency: 3)
+      expect(scanner.max_concurrency).to eq(3)
     end
   end
 


### PR DESCRIPTION
Add --max_concurrency option to set a number of HTTP requests to scan